### PR TITLE
Feat/make page flow init : 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,27 +12,29 @@ module.exports = {
   // 린트에는 기본적으로 제공하는 rule 말고도 추가로 rule을 제공하는 다양한 plugin이 제공한다. 해당 plugin을 추가함으로써 plugin의 rule을 적용할 수 있다.
   // eslint-plugin- 으로 시작하는 패키지들
   // 플로그인만 추가한다고 관련 규칙이 활성화 되는 것이 아니다. extends나 rule에 추가해줘야 한다.
-  plugins: ["react", "react-hooks", "jsx-a11y", "import"],
+  plugins: ['react', 'react-hooks', 'jsx-a11y', 'import'],
   // 기본 rule들 설정해놓은 템플릿을 가져와서 쓰자!
   // eslint-config- 로 시작하는 패키지들
   extends: [
-    "eslint:recommended", // eslint 기본 설정
-    "plugin:react/recommended", // eslint 기본 설정
-    "plugin:react-hooks/recommended",
-    "plugin:jsx-a11y/recommended",
-    "plugin:import/recommended",
-    "plugin:import/typescript",
-    "plugin:storybook/recommended",
-    "prettier", // eslitn의 style forammting에 있어서 prettier의 rlue로 우선하도록 eslint-config-prettier를 사용한다.
+    'eslint:recommended', // eslint 기본 설정
+    'plugin:react/recommended', // eslint 기본 설정
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:import/recommended',
+    'prettier', // eslitn의 style forammting에 있어서 prettier의 rlue로 우선하도록 eslint-config-prettier를 사용한다.
   ],
   rules: {
-    "jsx-a11y/no-autofocus": "warn",
-    "jsx-a11y/label-has-associated-control": "off",
+    'jsx-a11y/no-autofocus': 'warn',
+    'jsx-a11y/label-has-associated-control': 'off',
+    'react/react-in-jsx-scope': 'off', // 실효성 없다고 생각함. 개발 효율성 저하.
+    'no-unused-vars': 'warn', // 개발 효율성 저하
+    'import/no-unresolved': 'off', // 경로 효율성
+    'react/prop-types': 'warn', // TODO : 추후 변경 예정
   },
   // ESLint는 기본적으로 순수한 자바스크립트 코드만 이해(분석)할 수 있다.
   // 확장문법(ts), 최신문법으로 작성한 코드를 린트하기 위해서는 상응하는 parser가 필요하다.
   // 타입스크립트와 jsx를 사용하여 작성된 코드를 lint할 경우 아래와 같은 parser 가 필요하다.
-  ignorePatterns: ["**/*.stories.*"],
+  ignorePatterns: ['**/*.stories.*'],
   // 기본적으로 node_modules폴더나 '.'로 시작하는 설정파일은 무시한다. 그 외에 무시하고 싶은 패턴 기입
   // .gitignore처럼 .eslintignore파일 생성하여 무시하는 것도 방법
   overrides: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.17.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -3485,6 +3486,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
+      "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15074,6 +15083,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
+      "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
+      "dependencies": {
+        "@remix-run/router": "1.10.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
+      "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
+      "dependencies": {
+        "@remix-run/router": "1.10.0",
+        "react-router": "6.17.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,14 @@ import { Route, Routes } from 'react-router-dom';
 import MakeDesignPage from './pages/MakeDesignPage/MakeDesignPage';
 import MakeInfoPage from './pages/MakeInfoPage/MakeInfoPage';
 import PageTemplate from './pages/PageTemplate/PageTemplate';
+import HomePage from './pages/HomePage/HomePage';
 
 function App() {
   return (
     <PageTemplate>
       <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/make" element={<MakeInfoPage />} />
         <Route path="/make/info" element={<MakeInfoPage />} />
         <Route path="/make/design" element={<MakeDesignPage />} />
       </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,13 @@
-import PageTemplate from "./pages/PageTemplate/PageTemplate";
-import TodoListPage from "./pages/TodoListPage/TodoListPage";
+import MakeDesignPage from './pages/MakeDesignPage/MakeDesignPage';
+import MakeInfoPage from './pages/MakeInfoPage/MakeInfoPage';
+import PageTemplate from './pages/PageTemplate/PageTemplate';
 
 function App() {
   return (
     <PageTemplate>
-      <TodoListPage />
+      {/* <TodoListPage /> */}
+      <MakeInfoPage />
+      {/* <MakeDesignPage /> */}
     </PageTemplate>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { Route, Routes } from 'react-router-dom';
 import MakeDesignPage from './pages/MakeDesignPage/MakeDesignPage';
 import MakeInfoPage from './pages/MakeInfoPage/MakeInfoPage';
 import PageTemplate from './pages/PageTemplate/PageTemplate';
@@ -5,9 +6,10 @@ import PageTemplate from './pages/PageTemplate/PageTemplate';
 function App() {
   return (
     <PageTemplate>
-      {/* <TodoListPage /> */}
-      <MakeInfoPage />
-      {/* <MakeDesignPage /> */}
+      <Routes>
+        <Route path="/make/info" element={<MakeInfoPage />} />
+        <Route path="/make/design" element={<MakeDesignPage />} />
+      </Routes>
     </PageTemplate>
   );
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,12 +1,15 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
-import GlobalStyle from "./commons/style/GlobalStyle";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import GlobalStyle from './commons/style/GlobalStyle';
+import { BrowserRouter } from 'react-router-dom';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <GlobalStyle />
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
 );

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+
+const HomePage = () => {
+  const navigate = useNavigate();
+  const handleViewClick = () => {
+    navigate('/view/');
+  };
+  const handleMakeClick = () => {
+    navigate('/make/');
+  };
+
+  return (
+    <div>
+      <h1>HomePage</h1>
+      <button onClick={handleViewClick}>view</button>
+      <br />
+      <button onClick={handleMakeClick}>make</button>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/pages/MakeDesignPage/MakeDesignPage.jsx
+++ b/src/pages/MakeDesignPage/MakeDesignPage.jsx
@@ -1,0 +1,9 @@
+const MakeDesignPage = () => {
+  return (
+    <div>
+      <h1>MakeDesignpage</h1>
+    </div>
+  );
+};
+
+export default MakeDesignPage;

--- a/src/pages/MakeInfoPage/MakeInfoPage.jsx
+++ b/src/pages/MakeInfoPage/MakeInfoPage.jsx
@@ -1,0 +1,9 @@
+const MakeInfoPage = () => {
+  return (
+    <div>
+      <h1>MakeInfoPage</h1>
+    </div>
+  );
+};
+
+export default MakeInfoPage;

--- a/src/pages/MakeInfoPage/MakeInfoPage.jsx
+++ b/src/pages/MakeInfoPage/MakeInfoPage.jsx
@@ -1,8 +1,69 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const Container = styled.div`
+  input {
+    background-color: white;
+  }
+
+  button {
+    border: 2px solid black;
+    background-color: white;
+  }
+`;
+
 const MakeInfoPage = () => {
+  const navigate = useNavigate();
+
+  const [info, setInfo] = useState({
+    intro: '',
+    link: '',
+    image: '',
+  });
+  const [image, setImage] = useState(null);
+
+  const handleInfoChange = (e) => {
+    let { id, value } = e.target;
+    if (id === 'image') value = e.target.files[0];
+
+    setInfo({
+      ...info,
+      [id]: value,
+    });
+
+    if (id === 'image') {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result);
+      };
+      reader.readAsDataURL(value);
+    }
+  };
+
+  const handleSubmitClick = () => {
+    navigate('/make/design');
+  };
+
   return (
-    <div>
+    <Container>
       <h1>MakeInfoPage</h1>
-    </div>
+      <form>
+        <label htmlFor="intro">intro</label>
+        <input type="text" id="intro" onChange={handleInfoChange} />
+        <br />
+        <label htmlFor="link">link</label>
+        <input type="text" id="link" onChange={handleInfoChange} />
+        <br />
+        <label htmlFor="image">image</label>
+        <input type="file" id="image" onChange={handleInfoChange} />
+        <br />
+      </form>
+      {image && <img src={image} alt="preview" />}
+      <button type="button" onClick={handleSubmitClick}>
+        submit
+      </button>
+    </Container>
   );
 };
 


### PR DESCRIPTION
### Description
- 간이로 homepage를 만들었습니다.
![image](https://github.com/devBuzz142/numanku-fe/assets/19660039/eab11798-ba1e-43ac-918f-4511e190f8a9)
- 라우팅 구현
- make/intro 페이지 기초 구현
![image](https://github.com/devBuzz142/numanku-fe/assets/19660039/132dcc9a-2a7e-4c7b-92fe-d5e8e539e5a1)



### Implementation
- react-router-dom 설치했습니다.
- v6버전의 createBrowseRouter가 꽤 좋은 기능이긴 한데 당장 저희 서비스엔 꼭 필요한 건 아니고, v5기준이 처음 쓰시기엔 직관적이라서 프로토타입에선 v5버전식으로 코딩할 듯 합니다.
- index.jsx에서 <BrowseRouter>로 App을 감싸서 라우팅 지원하고
- App.jsx에서 라우팅하고 있습니다.

- 그냥 테스트할 때 편하게 하려고 간이로 홈페이지 만들었습니다.
- MakeInfoPage, MakeDesignPage 라우팅 설정 해놨습니다.

### 중점적으로 봐줬으면 하는 부분
- 추후 예정 사항
  - MakeInfoPage 구현
  - MakeDesignPage 구현
  - 백엔드 서버, db 구현
